### PR TITLE
Add examples to build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,8 @@ IF(GINACDE_BUILD_STATIC_LIBS)
     set(testlibs ${CORELIBS} GiNaCDE_static)
 ENDIF()
 
+add_subdirectory(examples EXCLUDE_FROM_ALL)
+
 add_executable(test1 test/test1.cpp)
 target_link_libraries(test1 ${testlibs})
 
@@ -166,4 +168,3 @@ ENDIF()
 # Installing headers
 install (FILES ${GINACDE_HEADERS} DESTINATION include/GiNaCDE)
 install (FILES "${PROJECT_BINARY_DIR}/version.h" DESTINATION include/GiNaCDE)
-

--- a/README.md
+++ b/README.md
@@ -82,7 +82,13 @@ Besides this, the solutions of the NLPDE are collected by a programming variable
 ## Examples
 The [`examples`](examples/) folder contains all the examples which solve some NLPDEs, such as, Eckhaus equation, Seventh-order SawadaKotara equations, Fifth-order Generalized KdV equation, Perturbed NLS Equation with Kerr Law Nonlinearity, KudryashovSinelshchikov Equation, etc.
 We have provided output text files after executing each example. 
-    
+
+To compile the examples, move to the `build-dir` created earlier for building GiNaCDE, and execute
+```
+$ make examples
+```
+The executables will be placed into the `build-dir/bin` directory.
+
 ### Additional notes
 Please note that one can obtain different results in output files compared to those provided by us in the [`examples`](examples/) folder for each example. 
 This happens because of the GiNaC library.

--- a/examples/5thGKdV.cpp
+++ b/examples/5thGKdV.cpp
@@ -7,7 +7,7 @@
 
 
 
-#include <GiNaCDE/GiNaCDE.h>
+#include <GiNaCDE.h>
 
 
 int main()

--- a/examples/7thorder.cpp
+++ b/examples/7thorder.cpp
@@ -7,7 +7,7 @@
 
 
 
-#include <GiNaCDE/GiNaCDE.h>
+#include <GiNaCDE.h>
 
 
 int main()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Source files in this directory
+set(SRC_FILES
+    5thGKdV
+    7thorder
+    Eckhaus
+    example1
+    example2
+    KdVB
+    kerrNLS
+    KS
+    NLS
+)
+
+# Add executables and link to library
+if(GINACDE_BUILD_SHARED_LIBS OR GINACDE_BUILD_STATIC_LIBS)
+    foreach(src ${SRC_FILES})
+        add_executable(${src} ${src}.cpp)
+        target_link_libraries(${src}
+            PUBLIC $<IF:$<BOOL:GINACDE_BUILD_SHARED_LIBS>,GiNaCDE,GiNaCDE_static>
+        )
+    endforeach()
+endif()
+
+# Add meta-target to compile
+add_custom_target(examples)
+add_dependencies(examples ${SRC_FILES})

--- a/examples/Eckhaus.cpp
+++ b/examples/Eckhaus.cpp
@@ -7,7 +7,7 @@
 
 
 
-#include <GiNaCDE/GiNaCDE.h>
+#include <GiNaCDE.h>
 
 
 int main()

--- a/examples/KS.cpp
+++ b/examples/KS.cpp
@@ -1,13 +1,13 @@
 
 /** @file KS.cpp
  *
- *   This program solves the Kudryashov–Sinelshchikov equation:
+ *   This program solves the Kudryashov<96>Sinelshchikov equation:
         {u_{3x}} + gu{u_x} - n{u_{2x}} - \left( {u{u_{2x}} + u_x^2} \right)d - k{u_x}{u_{2x}} - e\left( {u{u_{3x}} + {u_x}{u_{2x}}} \right) + {u_t} = 0,
     */
 
 
 
-#include <GiNaCDE/GiNaCDE.h>
+#include <GiNaCDE.h>
 
 
 int main()

--- a/examples/KS.cpp
+++ b/examples/KS.cpp
@@ -1,7 +1,7 @@
 
 /** @file KS.cpp
  *
- *   This program solves the Kudryashov<96>Sinelshchikov equation:
+ *   This program solves the Kudryashov-Sinelshchikov equation:
         {u_{3x}} + gu{u_x} - n{u_{2x}} - \left( {u{u_{2x}} + u_x^2} \right)d - k{u_x}{u_{2x}} - e\left( {u{u_{3x}} + {u_x}{u_{2x}}} \right) + {u_t} = 0,
     */
 

--- a/examples/KdVB.cpp
+++ b/examples/KdVB.cpp
@@ -7,7 +7,7 @@
 
 
 
-#include <GiNaCDE/GiNaCDE.h>
+#include <GiNaCDE.h>
 
 
 int main()

--- a/examples/NLS.cpp
+++ b/examples/NLS.cpp
@@ -7,7 +7,7 @@
 
 
 
-#include <GiNaCDE/GiNaCDE.h>
+#include <GiNaCDE.h>
 
 
 int main()

--- a/examples/example1.cpp
+++ b/examples/example1.cpp
@@ -8,7 +8,7 @@
 
 
 
-#include <GiNaCDE/GiNaCDE.h>
+#include <GiNaCDE.h>
 
 
 int main()

--- a/examples/example2.cpp
+++ b/examples/example2.cpp
@@ -19,7 +19,7 @@
         xvi. Nonlinear Telegraph Equation      */
 
 
-#include <GiNaCDE/GiNaCDE.h>
+#include <GiNaCDE.h>
 //#include <conio.h>
 
 

--- a/examples/kerrNLS.cpp
+++ b/examples/kerrNLS.cpp
@@ -7,7 +7,7 @@
 
 
 
-#include <GiNaCDE/GiNaCDE.h>
+#include <GiNaCDE.h>
 
 
 int main()


### PR DESCRIPTION
### What does this PR do?

Add the example source files as executables to the build system. This way, they can be easily built by executing
```
$ make examples
```

### Why was this PR suggested?

The examples would so far need to be compiled with commands to the compiler after installing GiNaCDE. Since they are part of the repository, it improves usability if they are included in the build system. This way, users do not need to install GiNaCDE to build and execute (and possibly also modify) the examples.

### Open questions

* The `examples/` folder also contains the output of the example executables. This can cause some issues as files that are produced by the code in a repository are often forgotten when updating the code. For example, the example files have been recently updated in aeeb00a89add8d01979ee6ced16d2a6432b5097c, with some files being renamed, but the old files have not been removed. Once the examples are part of the regular build system, it might be enough to just keep one single output file in the repository as an example. All other example output files can be easily recreated locally by running all the examples.

* I needed to update the includes from `<GiNaCDE/GiNaCDE.h>` to `<GiNaCDE.h>` for building the examples. This is against the instructions of the current `README.md`, but in line with the pkg-config include directory settings, see my comment in #8.

### Related issues

openjournals/joss-reviews#3885